### PR TITLE
change nodejs version to 14.20.1 (#1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:14.20.1
 
 RUN yarn global add caprover --prefix /usr/local
 


### PR DESCRIPTION
my github action failed to deploy to caprover with error 

```
Preparing deployment to CapRover...

Ensuring authentication...
Cannot find hash of last commit on branch "feat/HTR-2855".
```

Then I change the nodejs version to 14.20.1 and everythings works fine